### PR TITLE
Migrate to Windows 2019

### DIFF
--- a/.github/workflows/classic-release.yml
+++ b/.github/workflows/classic-release.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build-windows:
     name: 🪟 Build for Windows
-    runs-on: windows-2016
+    runs-on: windows-2019
     env:
       MOZ_NOSPAM: 1
     steps:

--- a/.github/workflows/classic.yml
+++ b/.github/workflows/classic.yml
@@ -81,7 +81,7 @@ jobs:
           path: ./dist/waterfox*.dmg
         if: env.ENABLE_ARTIFACTS_MODE == 'true'
   build-windows:
-    runs-on: windows-2016
+    runs-on: windows-2019
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2

--- a/.mozconfig
+++ b/.mozconfig
@@ -15,10 +15,10 @@ elif test $(uname -s) = MINGW32_NT-6.2; then
 	ac_add_options --enable-optimize="-O2 -Qvec -w -clang:-arch:SSE3"
 	ac_add_options --host=x86_64-pc-mingw32
 	ac_add_options --target=x86_64-pc-mingw32
-	ac_add_options --with-visual-studio-version=2017
-    if test -d "/c/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise"; then
-        export WIN32_REDIST_DIR="/c/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Redist/MSVC/14.16.27012/x64/Microsoft.VC141.CRT"
+    if test -d "/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise"; then
+        export WIN32_REDIST_DIR="/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC/14.16.27012/x64/Microsoft.VC141.CRT"
     else
+    	ac_add_options --with-visual-studio-version=2017
         export WIN32_REDIST_DIR="/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Redist/MSVC/14.16.27012/x64/Microsoft.VC141.CRT"
     fi
 	export WIN_UCRT_REDIST_DIR="/c/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64"


### PR DESCRIPTION
Microsoft says that `Windows-2016 environment will be removed on March 15, 2022`, so it's time to migrate to newer Windows :smile:.

