### PR TITLE
Fix build issues

### DIFF
--- a/.github/workflows/classic-release.yml
+++ b/.github/workflows/classic-release.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   ENABLE_ARTIFACTS_MODE: "true"
+  RUST_VER: "1.56.1"
   SHELL: "/bin/bash"
 
 jobs:
@@ -30,10 +31,10 @@ jobs:
           mkdir -p ~\\scoop\\buckets\\my-bucket
           Copy-Item -Path $env:GITHUB_WORKSPACE\\build\\github-actions\\mozilla-build.json -Destination ~\scoop\buckets\my-bucket
           scoop install my-bucket/mozilla-build --global
-          rustup default 1.56.1-pc-windows-msvc
+          rustup default $env:RUST_VER-pc-windows-msvc
       - name: Set system PATH variable
         shell: bash
-        run: sed -i 's/SET PATH=.*/&;C:\\Rust\\.cargo\\bin;C:\\ProgramData\\scoop\\shims/g' /c/ProgramData/scoop/apps/mozilla-build/current/start-shell.bat
+        run: sed -i 's/SET PATH=.*/&;C:\\Rust\\.cargo\\bin;C:\\ProgramData\\scoop\\shims;C:\\ProgramData\\scoop\\apps\\llvm\\current\\bin/g' /c/ProgramData/scoop/apps/mozilla-build/current/start-shell.bat
       - name: Cache for Windows
         uses: actions/cache@v2
         with:
@@ -56,6 +57,7 @@ jobs:
 
       - name: Sign
         run: |
+          cd $G_WORKSPACE
           BROWSER_VERSION=`cat browser/config/version_display.txt`
           /c/ProgramData/scoop/shims/wget.exe https://github.com/ebourg/jsign/releases/download/4.0/jsign-4.0.jar -P /c/ProgramData/scoop/shims/
           chmod +x /c/ProgramData/scoop/shims/
@@ -109,6 +111,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/browser/config/version_display.txt') }}
       - name: Build
         run: |
+          rustup default ${RUST_VER}-x86_64-unknown-linux-gnu
           ./mach build
       - name: Package
         run: |
@@ -148,6 +151,7 @@ jobs:
         run: |
           brew update
           brew install autoconf@2.13 ccache make nasm yasm
+          rustup default ${RUST_VER}-x86_64-apple-darwin
       - name: Download SDK
         run: |
           wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.12.sdk.tar.xz
@@ -415,11 +419,11 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: ./dist/*.sha256
+          artifacts: ./dist/waterfox*.sha256
           tag: ${{ steps.previoustag.outputs.tag }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: Artifact_Classic_Checksum_${{ github.run_id }}
-          path: ./dist/*.sha256
+          path: ./dist/waterfox*.sha256

--- a/.github/workflows/classic.yml
+++ b/.github/workflows/classic.yml
@@ -7,9 +7,11 @@ on:
   pull_request:
     branches:
       - classic
+  workflow_dispatch: null
 
 env:
   ENABLE_ARTIFACTS_MODE: "true"
+  RUST_VER: "1.56.1"
   SHELL: "/bin/bash"
 
 jobs:
@@ -28,6 +30,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/browser/config/version_display.txt') }}
       - name: Build
         run: |
+          rustup default ${RUST_VER}-x86_64-unknown-linux-gnu
           ./mach build
       - name: Package
         run: |
@@ -54,7 +57,7 @@ jobs:
         run: |
           brew update
           brew install autoconf@2.13 ccache make nasm yasm
-          rustup default 1.56.1-x86_64-apple-darwin
+          rustup default ${RUST_VER}-x86_64-apple-darwin
       - name: Get SDK
         run: |
           wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.12.sdk.tar.xz
@@ -97,10 +100,10 @@ jobs:
           mkdir -p ~\\scoop\\buckets\\my-bucket
           Copy-Item -Path $env:GITHUB_WORKSPACE\\build\\github-actions\\mozilla-build.json -Destination ~\scoop\buckets\my-bucket
           scoop install my-bucket/mozilla-build --global
-          rustup default 1.56.1-pc-windows-msvc
+          rustup default $env:RUST_VER-pc-windows-msvc
       - name: Set system PATH variable
         shell: bash
-        run: sed -i 's/SET PATH=.*/&;C:\\Rust\\.cargo\\bin;C:\\ProgramData\\scoop\\shims/g' /c/ProgramData/scoop/apps/mozilla-build/current/start-shell.bat
+        run: sed -i 's/SET PATH=.*/&;C:\\Rust\\.cargo\\bin;C:\\ProgramData\\scoop\\shims;C:\\ProgramData\\scoop\\apps\\llvm\\current\\bin/g' /c/ProgramData/scoop/apps/mozilla-build/current/start-shell.bat
       - name: Cache for Windows
         uses: actions/cache@v2
         with:
@@ -131,7 +134,7 @@ jobs:
         run: |
           cd ./dist/
           mv ./Artifact_Classic_*_${{ github.run_id }}/waterfox*.* ./
-          checksumFile=$(basename waterfox*.zip | sed 's/.win64.zip//g' | sed 's/$/.sha256/g')
+          checksumFile=$(basename waterfox*.tar.bz2 | sed 's/.tar.bz2//g' | sed 's/$/.sha256/g')
           sha256sum waterfox*.tar.bz2 | tee -a "$checksumFile"
           sha256sum waterfox*.dmg | tee -a "$checksumFile"
           sha256sum waterfox*.zip | tee -a "$checksumFile"
@@ -140,5 +143,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Artifact_Classic_Checksum_${{ github.run_id }}
-          path: ./dist/*.sha256
+          path: ./dist/waterfox*.sha256
         if: env.ENABLE_ARTIFACTS_MODE == 'true'

--- a/Dockerfile.GA
+++ b/Dockerfile.GA
@@ -2,7 +2,6 @@ FROM centos:7
 ENV llvm_ver="7.0"
 ENV nasm_ver="2.15.05"
 ENV git_ver="2.33.1"
-ENV rust_ver="1.56.1"
 ENV PATH="/opt/rh/llvm-toolset-${llvm_ver}/root/usr/bin:/root/.cargo/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/llvm-toolset-${llvm_ver}/root/usr/lib64:${LD_LIBRARY_PATH}"
 RUN yum -y install "deltarpm" "centos-release-scl-rh" "epel-release"
@@ -21,10 +20,8 @@ RUN yum -y update
 RUN yum -y install "llvm-toolset-${llvm_ver}-clang" "llvm-toolset-${llvm_ver}-llvm-devel"
 RUN clang --version
 RUN yum -y install "ccache" "which" "pkgconfig" "python2-devel" "python36" "alsa-lib-devel" "autoconf213" "pkgconfig(gl)" "pkgconfig(dbus-glib-1)" "libnotify-devel" "libproxy-devel" "startup-notification-devel" "unzip" "zip" "pkgconfig(xt)" "yasm" "pkgconfig(gdk-x11-2.0)" "pkgconfig(glib-2.0)" "pkgconfig(gobject-2.0)" "pkgconfig(gtk+-2.0)" "pkgconfig(gtk+-3.0)" "pkgconfig(gtk+-unix-print-2.0)" "pkgconfig(gtk+-unix-print-3.0)" "libcurl-devel" "pkgconfig(libffi)" "pkgconfig(libpulse)" "pkgconfig(jack)" "libdrm-devel" "pkgconfig(gconf-2.0)" "bzip2" "gcc" "gcc-c++"
-# Install rust
+# Install rustup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN rustup default ${rust_ver}-x86_64-unknown-linux-gnu
-RUN cargo --version
 # Build nasm
 RUN mkdir -p ~/nasm/
 WORKDIR "$HOME/nasm"


### PR DESCRIPTION
Because of change in https://github.com/ScoopInstaller/Main/commit/e67da89a9ede76df82f34e1d3c4dfa615dcdc1c2, now there are no LLVM binaries in shims dir, so that's why I added `C:\\ProgramData\\scoop\\apps\\llvm\\current\\bin` to PATH used by mozilla-build.