### PR TITLE
Fix sandbox crashing with glibc/libc6 >=2.35

### DIFF
--- a/security/sandbox/linux/SandboxFilter.cpp
+++ b/security/sandbox/linux/SandboxFilter.cpp
@@ -354,6 +354,13 @@ public:
       case __NR_getrandom:
         return Allow();
 
+        // Bug 1651701: an API for restartable atomic sequences and
+        // per-CPU data; exposing information about CPU numbers and
+        // when threads are migrated or preempted isn't great but the
+        // risk should be relatively low.
+      case __NR_rseq:
+        return Allow();
+
 #ifdef MOZ_ASAN
       // ASAN's error reporter wants to know if stderr is a tty.
     case __NR_ioctl: {


### PR DESCRIPTION
#71