### PR TITLE
Backport bug 1174452 (Copying text with the style "white-space: pre;" does not preserve white space)

### DIFF
--- a/dom/base/Text.h
+++ b/dom/base/Text.h
@@ -43,14 +43,14 @@ public:
 
 inline mozilla::dom::Text* nsINode::GetAsText()
 {
-  return IsNodeOfType(eTEXT) ? static_cast<mozilla::dom::Text*>(this)
-                             : nullptr;
+  return IsText()  ? static_cast<mozilla::dom::Text*>(this)
+                   : nullptr;
 }
 
 inline const mozilla::dom::Text* nsINode::GetAsText() const
 {
-  return IsNodeOfType(eTEXT) ? static_cast<const mozilla::dom::Text*>(this)
-                             : nullptr;
+  return IsText() ? static_cast<const mozilla::dom::Text*>(this)
+                  : nullptr;
 }
 
 #endif // mozilla_dom_Text_h

--- a/dom/base/nsDocumentEncoder.cpp
+++ b/dom/base/nsDocumentEncoder.cpp
@@ -363,8 +363,15 @@ nsDocumentEncoder::SerializeNodeStart(nsINode* aNode,
                                       nsAString& aStr,
                                       nsINode* aOriginalNode)
 {
-  if (mNeedsPreformatScanning && aNode->IsElement()) {
-    mSerializer->ScanElementForPreformat(aNode->AsElement());
+  if (mNeedsPreformatScanning) {
+    if (aNode->IsElement()) {
+      mSerializer->ScanElementForPreformat(aNode->AsElement());
+    } else if (aNode->IsText()) {
+      const nsCOMPtr<nsINode> parent = aNode->GetParent();
+      if (parent && parent->IsElement()) {
+        mSerializer->ScanElementForPreformat(parent->AsElement());
+      }
+    }
   }
 
   if (!IsVisibleNode(aNode))
@@ -444,8 +451,15 @@ nsresult
 nsDocumentEncoder::SerializeNodeEnd(nsINode* aNode,
                                     nsAString& aStr)
 {
-  if (mNeedsPreformatScanning && aNode->IsElement()) {
-    mSerializer->ForgetElementForPreformat(aNode->AsElement());
+  if (mNeedsPreformatScanning) {
+    if (aNode->IsElement()) {
+      mSerializer->ForgetElementForPreformat(aNode->AsElement());
+    } else if (aNode->IsText()) {
+      const nsCOMPtr<nsINode> parent = aNode->GetParent();
+      if (parent && parent->IsElement()) {
+        mSerializer->ForgetElementForPreformat(parent->AsElement());
+      }
+    }
   }
 
   if (!IsVisibleNode(aNode))

--- a/dom/base/nsINode.h
+++ b/dom/base/nsINode.h
@@ -465,6 +465,17 @@ public:
     return const_cast<nsINode*>(this)->AsContent();
   }
 
+  /*
+   * Return whether the node is a Text node (which might be an actual
+   * textnode, or might be a CDATA section).
+   */
+  bool IsText() const
+  {
+    uint32_t nodeType = NodeType();
+    return nodeType == nsIDOMNode::TEXT_NODE ||
+           nodeType == nsIDOMNode::CDATA_SECTION_NODE;
+  }
+
   /**
    * Return this node as Text if it is one, otherwise null.  This is defined
    * inline in Text.h.

--- a/dom/base/test/test_bug116083.html
+++ b/dom/base/test/test_bug116083.html
@@ -16,6 +16,10 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=116083
 <div style="white-space: pre-wrap">foo  bar</div>
 <div style="white-space: pre-line">foo  bar</div>
 <div style="white-space: -moz-pre-space">foo  bar</div>
+<div style="white-space: pre" data-collapse-selection-to-child-and-extend>foo  bar</div>
+<div style="white-space: pre-wrap" data-collapse-selection-to-child-and-extend>foo  bar</div>
+<div style="white-space: pre-line" data-collapse-selection-to-child-and-extend>foo  bar</div>
+<div style="white-space: -moz-pre-space" data-collapse-selection-to-child-and-extend>foo  bar</div>
 <div data-result="bar  baz"><span style="white-space: pre">bar  </span>baz</div>
 <div data-result="bar  baz"><span style="white-space: pre-wrap">bar  </span>baz</div>
 <div data-result="bar  baz"><span style="white-space: pre-line">bar  </span>baz</div>
@@ -70,16 +74,35 @@ function hasExpectedFlavors() {
   }
 }
 
+function collapseSelectionToChildAndExtend(divElement) {
+  is(divElement.childNodes.length, 1, "Expected exactly one child node.");
+  var textChildNode = divElement.childNodes[0];
+  getSelection().collapse(textChildNode);
+  getSelection().extend(textChildNode, divElement.textContent.length);
+}
+
+function selectDependingOnAttributes(divElement) {
+  if (divElement.hasAttribute("data-collapse-selection-to-child-and-extend")) {
+    // Selecting text as follow comes closest to user behaviour.
+    collapseSelectionToChildAndExtend(divElement);
+  } else {
+    getSelection().selectAllChildren(divElement);
+  }
+}
+
 function nextTest() {
   var div = document.querySelector("#content>div");
   if (!div) {
     SimpleTest.finish();
     return;
   }
-  getSelection().selectAllChildren(div);
+
+  selectDependingOnAttributes(div);
+
   var expected = div.hasAttribute("data-result") ?
                  div.getAttribute("data-result") :
                  div.textContent;
+
   SimpleTest.waitForClipboard(expected, function() {
     synthesizeKey("C", {accelKey: true});
   }, function() {

--- a/dom/base/test/test_user_select.html
+++ b/dom/base/test/test_user_select.html
@@ -285,7 +285,7 @@ function test()
   e = document.getElementById('testG');
   synthesizeMouse(e, 1, 1, {});
   synthesizeMouse(e, 400, 180, { shiftKey: true });
-  checkText("aaaa bbbb", e); // XXX this doesn't seem right - bug 1247799
+  checkText("aaaa\n\n\n\nbbbb", e);
   checkRanges([[0,0,-1,1],[2,0,-1,3],[4,0,-1,5],[6,0,6,5]], e);
   doneTest(e);
 
@@ -295,7 +295,7 @@ function test()
   synthesizeMouse(e, 30, 90, { shiftKey: true });
   synthesizeMouse(e, 50, 90, { shiftKey: true });
   synthesizeMouse(e, 70, 90, { shiftKey: true });
-  checkText("aaaa bbb", e);
+  checkText("aaaa\n\nbbb", e);
   checkRanges([[0,0,-1,1],[-1,2,3,4]], e);
 
   doneTest(e);


### PR DESCRIPTION
Making a text selection _inside_ a block of text formatted with `white-space: pre` and then copying that selection doesn't preserve the white space, i.e. especially newlines. 