### PR TITLE
Bug 1486296 - Use the same temp profile as mach run for launching Firefox from Visual Studio

### DIFF
--- a/python/mozbuild/mozbuild/backend/visualstudio.py
+++ b/python/mozbuild/mozbuild/backend/visualstudio.py
@@ -230,7 +230,8 @@ class VisualStudioBackend(CommonBackend):
             debugger=None
             if prefix == 'binary':
                 if item.startswith(self.environment.substs['MOZ_APP_NAME']):
-                    debugger = ('$(TopObjDir)\\dist\\bin\\%s' % item, '-no-remote')
+                    debugger = ('$(TopObjDir)\\dist\\bin\\%s' % item,
+                        '-no-remote -profile $(TopObjDir)\\tmp\\scratch_user')
                 else:
                     debugger = ('$(TopObjDir)\\dist\\bin\\%s' % item, '')
 


### PR DESCRIPTION
Small quality-of-life fix so hitting Run/Debug in Visual Studio doesn't accidentally use your regular browsing profile.