### PR TITLE
Switch to Safebrowsing v4 on Desktop builds

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1668,6 +1668,20 @@ pref("extensions.formautofill.loglevel", "Warn");
 // Whether or not to restore a session with lazy-browser tabs.
 pref("browser.sessionstore.restore_tabs_lazily", true);
 
+// Enable safebrowsing v4 tables (suffixed by "-proto") update.
+pref("urlclassifier.malwareTable", "goog-malware-proto,goog-unwanted-proto,test-malware-simple,test-unwanted-simple");
+#ifdef MOZILLA_OFFICIAL
+// In the official build, we are allowed to use google's private
+// phishing list "goog-phish-shavar". See Bug 1288840.
+pref("urlclassifier.phishTable", "goog-phish-proto,test-phish-simple");
+#else
+pref("urlclassifier.phishTable", "googpub-phish-proto,test-phish-simple");
+#endif
+
+// Tables for application reputation.
+pref("urlclassifier.downloadAllowTable", "goog-downloadwhite-proto");
+pref("urlclassifier.downloadBlockTable", "goog-badbinurl-proto");
+
 pref("browser.suppress_first_window_animation", true);
 
 // Preferences for Photon onboarding system extension


### PR DESCRIPTION
The rollout of Safebrowsing v4 in Firefox happened right during v56, but was
controlled via a system add-on and not made permanent until v57.
The old v2-API that Firefox was using until then subsequently stopped working
at some point in 2018. (Though unless you supply an API key, which Waterfox by
default doesn't, it wouldn't work either way, anyway.)

This is based along the lines of
https://hg.mozilla.org/mozilla-central/rev/bca021fc3073, but I created the patch
from scratch based on Waterfox's current set of safebrowsing prefs.

Android likely needs a few more bugfixes backported (and currently doesn't build
anyway), so this only switches the Desktop prefs.

Note that Waterfox includes [bug 1336915](https://bugzilla.mozilla.org/show_bug.cgi?id=1336915), so unless explicitly supplying an API key during building (which you don't), Safebrowsing will remain turned off internally and no API requests will be made to Google.