### PR TITLE
Fix JS debug asserts on startup

### DIFF
--- a/js/src/builtin/RegExp.cpp
+++ b/js/src/builtin/RegExp.cpp
@@ -143,26 +143,29 @@ js::CreateRegExpMatchResult(JSContext* cx,
 
     /* Step 20 (reordered).
      * Set the |index| property. (TemplateObject positions it in slot 0) */
-    arr->setSlot(0, Int32Value(matches[0].start));
+    arr->setSlot(RegExpCompartment::MatchResultObjectIndexSlot,
+                 Int32Value(matches[0].start));
 
     /* Step 21 (reordered).
      * Set the |input| property. (TemplateObject positions it in slot 1) */
-    arr->setSlot(1, StringValue(input));
+    arr->setSlot(RegExpCompartment::MatchResultObjectInputSlot,
+                 StringValue(input));
 
     // Steps 25-26 (reordered)
     // Set the |groups| property.
-    arr->setSlot(2, groups ? ObjectValue(*groups) : UndefinedValue());
+    arr->setSlot(RegExpCompartment::MatchResultObjectGroupsSlot,
+                 groups ? ObjectValue(*groups) : UndefinedValue());
 
 #ifdef DEBUG
     RootedValue test(cx);
     RootedId id(cx, NameToId(cx->names().index));
     if (!NativeGetProperty(cx, arr, id, &test))
         return false;
-    MOZ_ASSERT(test == arr->getSlot(0));
+    MOZ_ASSERT(test == arr->getSlot(RegExpCompartment::MatchResultObjectIndexSlot));
     id = NameToId(cx->names().input);
     if (!NativeGetProperty(cx, arr, id, &test))
         return false;
-    MOZ_ASSERT(test == arr->getSlot(1));
+    MOZ_ASSERT(test == arr->getSlot(RegExpCompartment::MatchResultObjectInputSlot));
 #endif
 
     // Step 28.

--- a/js/src/jsstr.cpp
+++ b/js/src/jsstr.cpp
@@ -3593,10 +3593,8 @@ static const JSFunctionSpec string_methods[] = {
     JS_FN("startsWith",        str_startsWith,        1,0),
     JS_FN("endsWith",          str_endsWith,          1,0),
     JS_FN("trim",              str_trim,              0,0),
-    JS_FN("trimLeft",          str_trimStart,         0,0),
-	JS_FN("trimStart",         str_trimStart,         0,0),
-    JS_FN("trimRight",         str_trimEnd,           0,0),
-	JS_FN("trimEnd",           str_trimEnd,           0,0),
+    JS_FN("trimStart",         str_trimStart,         0,0),
+    JS_FN("trimEnd",           str_trimEnd,           0,0),
 #if EXPOSE_INTL_API
     JS_SELF_HOSTED_FN("toLocaleLowerCase", "String_toLocaleLowerCase", 0,0),
     JS_SELF_HOSTED_FN("toLocaleUpperCase", "String_toLocaleUpperCase", 0,0),
@@ -3904,9 +3902,7 @@ static const JSFunctionSpec string_static_methods[] = {
     JS_SELF_HOSTED_FN("startsWith",      "String_static_startsWith",    2,0),
     JS_SELF_HOSTED_FN("endsWith",        "String_static_endsWith",      2,0),
     JS_SELF_HOSTED_FN("trim",            "String_static_trim",          1,0),
-    JS_SELF_HOSTED_FN("trimLeft",        "String_static_trimStart",     1,0),
     JS_SELF_HOSTED_FN("trimStart",       "String_static_trimStart",     1,0),
-    JS_SELF_HOSTED_FN("trimRight",       "String_static_trimEnd",       1,0),
     JS_SELF_HOSTED_FN("trimEnd",         "String_static_trimEnd",       1,0),
     JS_SELF_HOSTED_FN("toLocaleLowerCase","String_static_toLocaleLowerCase",1,0),
     JS_SELF_HOSTED_FN("toLocaleUpperCase","String_static_toLocaleUpperCase",1,0),
@@ -3955,6 +3951,25 @@ js::InitStringClass(JSContext* cx, HandleObject obj)
 
     if (!DefinePropertiesAndFunctions(cx, proto, nullptr, string_methods) ||
         !DefinePropertiesAndFunctions(cx, ctor, nullptr, string_static_methods))
+    {
+        return nullptr;
+    }
+
+    // Create "trimLeft" as an alias for "trimStart".
+    RootedValue trimFn(cx);
+    RootedId trimId(cx, NameToId(cx->names().trimStart));
+    RootedId trimAliasId(cx, NameToId(cx->names().trimLeft));
+    if (!NativeGetProperty(cx, protoObj, trimId, &trimFn) ||
+        !NativeDefineProperty(cx, protoObj, trimAliasId, trimFn, nullptr, nullptr, 0))
+    {
+        return nullptr;
+    }
+
+    // Create "trimRight" as an alias for "trimEnd".
+    trimId = NameToId(cx->names().trimEnd);
+    trimAliasId = NameToId(cx->names().trimRight);
+    if (!NativeGetProperty(cx, protoObj, trimId, &trimFn) ||
+        !NativeDefineProperty(cx, protoObj, trimAliasId, trimFn, nullptr, nullptr, 0))
     {
         return nullptr;
     }

--- a/js/src/vm/CommonPropertyNames.h
+++ b/js/src/vm/CommonPropertyNames.h
@@ -400,6 +400,10 @@
     macro(timestamp, timestamp, "timestamp") \
     macro(timeZone, timeZone, "timeZone") \
     macro(timeZoneName, timeZoneName, "timeZoneName") \
+    macro(trimEnd, trimEnd, "trimEnd") \
+    macro(trimLeft, trimLeft, "trimLeft") \
+    macro(trimRight, trimRight, "trimRight") \
+    macro(trimStart, trimStart, "trimStart") \
     macro(toGMTString, toGMTString, "toGMTString") \
     macro(toISOString, toISOString, "toISOString") \
     macro(toJSON, toJSON, "toJSON") \

--- a/js/src/vm/RegExpObject.cpp
+++ b/js/src/vm/RegExpObject.cpp
@@ -955,13 +955,13 @@ RegExpCompartment::createMatchResultTemplateObject(JSContext* cx)
     // Make sure that the properties are in the right slots.
 #ifdef DEBUG
   Shape* groupsShape = templateObject->lastProperty();
-  MOZ_ASSERT(groupsShape->slot() == 0 &&
+  MOZ_ASSERT(groupsShape->slot() == MatchResultObjectGroupsSlot &&
              groupsShape->propidRef() == NameToId(cx->names().groups));
   Shape* inputShape = groupsShape->previous().get();
-  MOZ_ASSERT(inputShape->slot() == 1 &&
+  MOZ_ASSERT(inputShape->slot() == MatchResultObjectInputSlot &&
              inputShape->propidRef() == NameToId(cx->names().input));
   Shape* indexShape = inputShape->previous().get();
-  MOZ_ASSERT(indexShape->slot() == 2 &&
+  MOZ_ASSERT(indexShape->slot() == MatchResultObjectIndexSlot &&
              indexShape->propidRef() == NameToId(cx->names().index));
 #endif
 

--- a/js/src/vm/RegExpShared.h
+++ b/js/src/vm/RegExpShared.h
@@ -372,6 +372,10 @@ class RegExpCompartment
 
     void sweep(JSRuntime* rt);
 
+    static const size_t MatchResultObjectIndexSlot = 0;
+    static const size_t MatchResultObjectInputSlot = 1;
+    static const size_t MatchResultObjectGroupsSlot = 2;
+
     /* Get or create template object used to base the result of .exec() on. */
     ArrayObject* getOrCreateMatchResultTemplateObject(JSContext* cx) {
         if (matchResultTemplateObject_)

--- a/js/src/vm/SelfHosting.cpp
+++ b/js/src/vm/SelfHosting.cpp
@@ -2306,9 +2306,7 @@ static const JSFunctionSpec intrinsic_functions[] = {
     JS_INLINABLE_FN("std_String_charAt",         str_charAt,                   1,0, StringCharAt),
     JS_FN("std_String_endsWith",                 str_endsWith,                 1,0),
     JS_FN("std_String_trim",                     str_trim,                     0,0),
-    JS_FN("std_String_trimLeft",                 str_trimStart,                0,0),
     JS_FN("std_String_trimStart",                str_trimStart,                0,0),
-    JS_FN("std_String_trimRight",                str_trimEnd,                  0,0),
     JS_FN("std_String_trimEnd",                  str_trimEnd,                  0,0),
 #if !EXPOSE_INTL_API
     JS_FN("std_String_toLocaleLowerCase",        str_toLocaleLowerCase,        0,0),


### PR DESCRIPTION
If I try to run Waterfox with `--enable-debug` enabled, I'm immediately hitting some assertions in JS code. These two commits fix them, allowing Waterfox to successfully start up at least. (Eventually you might hit other assertions, e.g. I'm hitting one in NSS code on shutdown, and another somewhere when trying to open the devtools, but at least things are no longer completely broken.)

I've manually tested the `trimLeft()`/`trimRight()` aliases and they seem to continue working even with this new implementation.