### PR TITLE
Fix backport of bug 1683940

### DIFF
--- a/browser/extensions/pdfjs/content/PdfJsNetwork.jsm
+++ b/browser/extensions/pdfjs/content/PdfJsNetwork.jsm
@@ -94,7 +94,7 @@ var NetworkManager = (function NetworkManagerClosure() {
         var rangeStr = args.begin + "-" + (args.end - 1);
         xhr.setRequestHeader("Range", "bytes=" + rangeStr);
         pendingRequest.expectedStatus = 206;
-        xhr.channel.QueryInterface(Ci.nsIHttpChannel).redirectionLimit = 0;
+        xhr.channel.QueryInterface(Components.interfaces.nsIHttpChannel).redirectionLimit = 0;
       } else {
         pendingRequest.expectedStatus = 200;
       }


### PR DESCRIPTION
While loading a PDF file, I noticed a ReferenceError showing up in the browser console. It turns out that for whatever reasons, in Waterfox the 'Ci' shorthand isn't defined within the context of this file.