### PR TITLE
Fix MFSA 2022-19

### DIFF
--- a/dom/notification/NotificationDB.jsm
+++ b/dom/notification/NotificationDB.jsm
@@ -47,8 +47,8 @@ var NotificationDB = {
       return;
     }
 
-    this.notifications = {};
-    this.byTag = {};
+    this.notifications = Object.create(null);
+    this.byTag = Object.create(null);
     this.loaded = false;
 
     this.tasks = []; // read/write operation queue
@@ -112,7 +112,7 @@ var NotificationDB = {
         // populate the list of notifications by tag
         if (this.notifications) {
           for (var origin in this.notifications) {
-            this.byTag[origin] = {};
+            this.byTag[origin] = Object.create(null);
             for (var id in this.notifications[origin]) {
               var curNotification = this.notifications[origin][id];
               if (curNotification.tag) {
@@ -314,8 +314,8 @@ var NotificationDB = {
     var origin = data.origin;
     var notification = data.notification;
     if (!this.notifications[origin]) {
-      this.notifications[origin] = {};
-      this.byTag[origin] = {};
+      this.notifications[origin] = Object.create(null);
+      this.byTag[origin] = Object.create(null);
     }
 
     // We might have existing notification with this tag,

--- a/dom/notification/NotificationDB.jsm
+++ b/dom/notification/NotificationDB.jsm
@@ -80,22 +80,23 @@ var NotificationDB = {
   },
 
   filterNonAppNotifications: function(notifications) {
+    let result = Object.create(null);
     for (let origin in notifications) {
+      result[origin] = Object.create(null);
       let persistentNotificationCount = 0;
       for (let id in notifications[origin]) {
         if (notifications[origin][id].serviceWorkerRegistrationScope) {
           persistentNotificationCount++;
-        } else {
-          delete notifications[origin][id];
+          result[origin][id] = notifications[origin][id];
         }
       }
       if (persistentNotificationCount == 0) {
         if (DEBUG) debug("Origin " + origin + " is not linked to an app manifest, deleting.");
-        delete notifications[origin];
+        delete result[origin];
       }
     }
 
-    return notifications;
+    return result;
   },
 
   // Attempt to read notification file, if it's not there we will create it.

--- a/js/src/builtin/Date.js
+++ b/js/src/builtin/Date.js
@@ -34,7 +34,7 @@
 //    consistent with cached values, then
 // 2) seeing if the desired formatter is cached and returning it if so, or else
 // 3) create the desired formatter and store and return it.
-var dateTimeFormatCache = new Record();
+var dateTimeFormatCache = new_Record();
 
 
 /**
@@ -56,7 +56,7 @@ function GetCachedFormat(format, required, defaults) {
     if (!IsRuntimeDefaultLocale(dateTimeFormatCache.runtimeDefaultLocale) ||
         !intl_isDefaultTimeZone(dateTimeFormatCache.icuDefaultTimeZone))
     {
-        formatters = dateTimeFormatCache.formatters = new Record();
+        formatters = dateTimeFormatCache.formatters = new_Record();
         dateTimeFormatCache.runtimeDefaultLocale = RuntimeDefaultLocale();
         dateTimeFormatCache.icuDefaultTimeZone = intl_defaultTimeZone();
     } else {

--- a/js/src/builtin/Module.js
+++ b/js/src/builtin/Module.js
@@ -13,7 +13,7 @@ function CallModuleResolveHook(module, specifier, expectedMinimumStatus)
 }
 
 // 15.2.1.16.2 GetExportedNames(exportStarSet)
-function ModuleGetExportedNames(exportStarSet = [])
+function ModuleGetExportedNames(exportStarSet = new_List())
 {
     if (!IsObject(this) || !IsModule(this)) {
         return callFunction(CallModuleMethodIfWrapped, this, exportStarSet,
@@ -25,13 +25,13 @@ function ModuleGetExportedNames(exportStarSet = [])
 
     // Step 2
     if (callFunction(ArrayIncludes, exportStarSet, module))
-        return [];
+        return new_List();
 
     // Step 3
     _DefineDataProperty(exportStarSet, exportStarSet.length, module);
 
     // Step 4
-    let exportedNames = [];
+    let exportedNames = new_List();
     let namesCount = 0;
 
     // Step 5
@@ -97,7 +97,7 @@ function ModuleSetStatus(module, newStatus)
 //  - If the request is found to be ambiguous, the string `"ambiguous"` is
 //    returned.
 //
-function ModuleResolveExport(exportName, resolveSet = [])
+function ModuleResolveExport(exportName, resolveSet = new_List())
 {
     if (!IsObject(this) || !IsModule(this)) {
         return callFunction(CallModuleMethodIfWrapped, this, exportName, resolveSet,
@@ -199,7 +199,7 @@ function GetModuleNamespace(module)
     // Step 3
     if (typeof namespace === "undefined") {
         let exportedNames = callFunction(module.getExportedNames, module);
-        let unambiguousNames = [];
+        let unambiguousNames = new_List();
         for (let i = 0; i < exportedNames.length; i++) {
             let name = exportedNames[i];
             let resolution = callFunction(module.resolveExport, module, name);
@@ -292,7 +292,7 @@ function ModuleInstantiate()
     }
 
     // Step 3
-    let stack = [];
+    let stack = new_List();
 
     // Steps 4-5
     try {
@@ -522,7 +522,7 @@ function ModuleEvaluate()
     }
 
     // Step 3
-    let stack = [];
+    let stack = new_List();
 
     // Steps 4-5
     try {

--- a/js/src/builtin/Number.js
+++ b/js/src/builtin/Number.js
@@ -5,7 +5,7 @@
 /*global intl_NumberFormat: false, */
 
 
-var numberFormatCache = new Record();
+var numberFormatCache = new_Record();
 
 
 /**

--- a/js/src/builtin/RegExp.js
+++ b/js/src/builtin/RegExp.js
@@ -342,7 +342,7 @@ function RegExpReplaceSlowPath(rx, S, lengthS, replaceValue,
     }
 
     // Step 9.
-    var results = [];
+    var results = new_List();
     var nResults = 0;
 
     // Step 11.
@@ -449,7 +449,7 @@ function RegExpGetComplexReplacement(result, matched, S, position,
                                      functionalReplace, firstDollarIndex)
 {
     // Step 14.h.
-    var captures = [];
+    var captures = new_List();
     var capturesLength = 0;
 
     // Step 14.k.i (reordered).
@@ -539,7 +539,7 @@ function RegExpGetFunctionalReplacement(result, S, position, replaceValue) {
     }
 
     // Steps 14.g-i, 14.k.i-ii.
-    var captures = [];
+    var captures = new_List();
     for (var n = 0; n <= nCaptures; n++) {
         assert(typeof result[n] === "string" || result[n] === undefined,
                "RegExpMatcher returns only strings and undefined");

--- a/js/src/builtin/Sorting.js
+++ b/js/src/builtin/Sorting.js
@@ -292,8 +292,8 @@ function MergeSort(array, len, comparefn) {
     }
 
     // We do all of our allocating up front
-    var lBuffer = new List();
-    var rBuffer = new List();
+    var lBuffer = new_List();
+    var rBuffer = new_List();
 
     var mid, end;
     for (var windowSize = 1; windowSize < denseLen; windowSize = 2 * windowSize) {
@@ -358,7 +358,7 @@ function QuickSort(array, len, comparefn) {
     assert(0 <= len && len <= 0x7FFFFFFF, "length is a positive int32 value");
 
     // Managing the stack ourselves seems to provide a small performance boost.
-    var stack = new List();
+    var stack = new_List();
     var top = 0;
 
     var start = 0;

--- a/js/src/builtin/String.js
+++ b/js/src/builtin/String.js
@@ -720,7 +720,7 @@ function StringIteratorNext() {
     return result;
 }
 
-var collatorCache = new Record();
+var collatorCache = new_Record();
 
 /**
  * Compare this String against that String, using the locale and collation

--- a/js/src/builtin/TypedArray.js
+++ b/js/src/builtin/TypedArray.js
@@ -384,7 +384,7 @@ function TypedArrayFilter(callbackfn/*, thisArg*/) {
     var T = arguments.length > 1 ? arguments[1] : void 0;
 
     // Step 6.
-    var kept = new List();
+    var kept = new_List();
 
     // Step 8.
     var captured = 0;

--- a/js/src/builtin/TypedObject.js
+++ b/js/src/builtin/TypedObject.js
@@ -1095,7 +1095,7 @@ function BuildTypedSeqImpl(arrayType, len, depth, func) {
   // Create a zeroed instance with no data
   var result = new arrayType();
 
-  var indices = new List();
+  var indices = new_List();
   indices.length = depth;
   for (var i = 0; i < depth; i++) {
     indices[i] = 0;
@@ -1128,7 +1128,7 @@ function ComputeIterationSpace(arrayType, depth, len) {
   assert(IsObject(arrayType) && ObjectIsTypeDescr(arrayType), "ComputeIterationSpace called on non-type-object");
   assert(TypeDescrIsArrayType(arrayType), "ComputeIterationSpace called on non-array-type");
   assert(depth > 0, "ComputeIterationSpace called on non-positive depth");
-  var iterationSpace = new List();
+  var iterationSpace = new_List();
   iterationSpace.length = depth;
   iterationSpace[0] = len;
   var totalLength = len;
@@ -1299,7 +1299,7 @@ function MapTypedSeqImpl(inArray, depth, outputType, func) {
   function DoMapTypedSeqDepthN() {
     // Simulate Uint32Array(depth) with a dumber (and more accessible)
     // datastructure.
-    var indices = new List();
+    var indices = new_List();
     for (var i = 0; i < depth; i++)
         callFunction(std_Array_push, indices, 0);
 

--- a/js/src/builtin/Utilities.js
+++ b/js/src/builtin/Utilities.js
@@ -59,16 +59,7 @@ var std_WeakMap = WeakMap;
 var std_StopIteration = StopIteration;
 
 
-/********** List / Record specification types **********/
-
-// A "List" is an internal type used in the ECMAScript spec to define a simple
-// ordered list of values. It is never exposed to user script, but we use a
-// simple Object (with null prototype) as a convenient implementation.
-//
-// NOTE: This does not track a `length` field.
-function new_List() {
-    return std_Object_create(null);
-}
+/********** Specification types **********/
 
 
 // A "Record" is an internal type used in the ECMAScript spec to define a struct

--- a/js/src/builtin/Utilities.js
+++ b/js/src/builtin/Utilities.js
@@ -59,23 +59,24 @@ var std_WeakMap = WeakMap;
 var std_StopIteration = StopIteration;
 
 
-/********** List specification type **********/
+/********** List / Record specification types **********/
 
-/* Spec: ECMAScript Language Specification, 5.1 edition, 8.8 */
-function List() {
-    this.length = 0;
-}
-MakeConstructible(List, {__proto__: null});
-
-
-/********** Record specification type **********/
-
-
-/* Spec: ECMAScript Internationalization API Specification, draft, 5 */
-function Record() {
+// A "List" is an internal type used in the ECMAScript spec to define a simple
+// ordered list of values. It is never exposed to user script, but we use a
+// simple Object (with null prototype) as a convenient implementation.
+//
+// NOTE: This does not track a `length` field.
+function new_List() {
     return std_Object_create(null);
 }
-MakeConstructible(Record, {});
+
+
+// A "Record" is an internal type used in the ECMAScript spec to define a struct
+// made up of key / values. It is never exposed to user script, but we use a
+// simple Object (with null prototype) as a convenient implementation.
+function new_Record() {
+    return std_Object_create(null);
+}
 
 
 /********** Abstract operations defined in ECMAScript Language Specification **********/

--- a/js/src/builtin/intl/Collator.js
+++ b/js/src/builtin/intl/Collator.js
@@ -151,7 +151,7 @@ function InitializeCollator(collator, locales, options) {
     lazyCollatorData.usage = u;
 
     // Step 8.
-    var opt = new Record();
+    var opt = new_Record();
     lazyCollatorData.opt = opt;
 
     // Steps 9-10.

--- a/js/src/builtin/intl/CommonFunctions.js
+++ b/js/src/builtin/intl/CommonFunctions.js
@@ -1025,7 +1025,7 @@ function BestAvailableLocaleIgnoringDefault(availableLocales, locale) {
  */
 function LookupMatcher(availableLocales, requestedLocales) {
     // Step 1.
-    var result = new Record();
+    var result = new_Record();
 
     // Step 2.
     for (var i = 0; i < requestedLocales.length; i++) {
@@ -1165,7 +1165,7 @@ function ResolveLocale(availableLocales, requestedLocales, options, relevantExte
     var extension = r.extension;
 
     // Step 5.
-    var result = new Record();
+    var result = new_Record();
 
     // Step 6.
     result.dataLocale = foundLocale;

--- a/js/src/builtin/intl/DateTimeFormat.js
+++ b/js/src/builtin/intl/DateTimeFormat.js
@@ -343,7 +343,7 @@ function InitializeDateTimeFormat(dateTimeFormat, thisValue, locales, options, m
 
     // Compute options that impact interpretation of locale.
     // Step 3.
-    var localeOpt = new Record();
+    var localeOpt = new_Record();
     lazyDateTimeFormatData.localeOpt = localeOpt;
 
     // Steps 4-5.
@@ -389,7 +389,7 @@ function InitializeDateTimeFormat(dateTimeFormat, thisValue, locales, options, m
     lazyDateTimeFormatData.timeZone = tz;
 
     // Step 21.
-    var formatOpt = new Record();
+    var formatOpt = new_Record();
     lazyDateTimeFormatData.formatOpt = formatOpt;
 
     lazyDateTimeFormatData.mozExtensions = mozExtensions;

--- a/js/src/builtin/intl/IntlObject.js
+++ b/js/src/builtin/intl/IntlObject.js
@@ -47,7 +47,7 @@ function Intl_getCalendarInfo(locales) {
     const localeData = DateTimeFormat.localeData;
 
     // 3. Let localeOpt be a new Record.
-    const localeOpt = new Record();
+    const localeOpt = new_Record();
 
     // 4. Set localeOpt.[[localeMatcher]] to "best fit".
     localeOpt.localeMatcher = "best fit";
@@ -119,7 +119,7 @@ function Intl_getDisplayNames(locales, options) {
     const localeData = DateTimeFormat.localeData;
 
     // 5. Let localeOpt be a new Record.
-    const localeOpt = new Record();
+    const localeOpt = new_Record();
 
     // 6. Set localeOpt.[[localeMatcher]] to "best fit".
     localeOpt.localeMatcher = "best fit";
@@ -203,7 +203,7 @@ function Intl_getLocaleInfo(locales) {
   const DateTimeFormat = dateTimeFormatInternalProperties;
   const localeData = DateTimeFormat.localeData;
 
-  const localeOpt = new Record();
+  const localeOpt = new_Record();
   localeOpt.localeMatcher = "best fit";
 
   const r = ResolveLocale(callFunction(DateTimeFormat.availableLocales, DateTimeFormat),

--- a/js/src/builtin/intl/NumberFormat.js
+++ b/js/src/builtin/intl/NumberFormat.js
@@ -254,7 +254,7 @@ function InitializeNumberFormat(numberFormat, thisValue, locales, options) {
 
     // Compute options that impact interpretation of locale.
     // Step 4.
-    var opt = new Record();
+    var opt = new_Record();
     lazyNumberFormatData.opt = opt;
 
     // Steps 5-6.

--- a/js/src/builtin/intl/PluralRules.js
+++ b/js/src/builtin/intl/PluralRules.js
@@ -143,7 +143,7 @@ function InitializePluralRules(pluralRules, locales, options) {
         options = ToObject(options);
 
     // Step 4.
-    let opt = new Record();
+    let opt = new_Record();
     lazyPluralRulesData.opt = opt;
 
     // Steps 5-6.

--- a/js/src/builtin/intl/RelativeTimeFormat.js
+++ b/js/src/builtin/intl/RelativeTimeFormat.js
@@ -119,7 +119,7 @@ function InitializeRelativeTimeFormat(relativeTimeFormat, locales, options) {
         options = ToObject(options);
 
     // Step 6.
-    let opt = new Record();
+    let opt = new_Record();
 
     // Steps 7-8.
     let matcher = GetOption(options, "localeMatcher", "string", ["lookup", "best fit"], "best fit");

--- a/js/src/jsarray.h
+++ b/js/src/jsarray.h
@@ -173,6 +173,8 @@ array_splice(JSContext* cx, unsigned argc, js::Value* vp);
 
 extern const JSJitInfo array_splice_info;
 
+extern bool intrinsic_newList(JSContext* cx, unsigned argc, js::Value* vp);
+
 /*
  * Append the given (non-hole) value to the end of an array.  The array must be
  * a newborn array -- that is, one which has not been exposed to script for

--- a/js/src/vm/SelfHosting.cpp
+++ b/js/src/vm/SelfHosting.cpp
@@ -2255,6 +2255,7 @@ intrinsic_PromiseResolve(JSContext* cx, unsigned argc, Value* vp)
 // Additionally, a set of C++-implemented helper functions is defined on the
 // self-hosting global.
 static const JSFunctionSpec intrinsic_functions[] = {
+    JS_FN("new_List",                            intrinsic_newList,            0,0),
     JS_INLINABLE_FN("std_Array",                 array_construct,              1,0, Array),
     JS_FN("std_Array_join",                      array_join,                   1,0),
     JS_INLINABLE_FN("std_Array_push",            array_push,                   1,0, ArrayPush),


### PR DESCRIPTION
As I've been poking around Spidermonkey anyway, this one addresses #119.

Discounting some minor formatting differences and the fact in Firefox the corresponding files have moved to the `old` subdirectory, the patches for 1770137 apply cleanly. Although if that issue really only applies in conjunction with Top-level await (maybe because nowadays this might possibly be used for *.jsm loading in Firefox?), then we currently don't support that feature  anyway.

For bug 1770048 I've started with the ESR patch and adapted it to the best of my knowledge based on the corresponding changes that happened between our code and the current ESR code base in the similar `NewArray()` function. Because of the changes to `utilities.js`, I've also had to pull in part 1 of bug hg 1705837.

(Also a small reminder to keep the original commits intact on merging if possible, and not squash them together.)