### PR TITLE
Bug 1542673, increase history.state size limit

### DIFF
--- a/docshell/base/nsDocShell.cpp
+++ b/docshell/base/nsDocShell.cpp
@@ -12190,9 +12190,9 @@ nsDocShell::AddState(JS::Handle<JS::Value> aData, const nsAString& aTitle,
   }
 
   // Check that the state object isn't too long.
-  // Default max length: 640k bytes.
+  // Default max length: 2097152 (0x200000) bytes.
   int32_t maxStateObjSize =
-    Preferences::GetInt("browser.history.maxStateObjectSize", 0xA0000);
+      Preferences::GetInt("browser.history.maxStateObjectSize", 2097152);
   if (maxStateObjSize < 0) {
     maxStateObjSize = 0;
   }

--- a/docshell/test/browser/file_multiple_pushState.html
+++ b/docshell/test/browser/file_multiple_pushState.html
@@ -9,6 +9,12 @@
   </body>
   <script type="text/javascript">
     window.history.pushState({}, "", "/bar/ABC?key=baz");
-    window.history.pushState({}, "", "/bar/ABC/DEF?key=baz");
+    let data = new Array(100000).join("a");
+    window.history.pushState({ data }, "", "/bar/ABC/DEF?key=baz");
+    // Test also Gecko specific state object size limit.
+    try {
+      let largeData = new Array(10000000).join("a");
+      window.history.pushState({ largeData }, "", "/bar/ABC/DEF/GHI?key=baz");
+    } catch (ex) {}
   </script>
 </html>

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -4973,7 +4973,7 @@ pref("html5.flushtimer.initialdelay", 120);
 pref("html5.flushtimer.subsequentdelay", 120);
 
 // Push/Pop/Replace State prefs
-pref("browser.history.maxStateObjectSize", 655360);
+pref("browser.history.maxStateObjectSize", 2097152);
 
 pref("browser.meta_refresh_when_inactive.disabled", false);
 


### PR DESCRIPTION
I've noticed that e.g. the brand overview pages on Zalando (i.e. like https://www.zalando.de/s-oliver/) fail to load because they're trying to push too much history state data onto the stack and are running into the old Firefox limit which currently still persists in Waterfox. So for compatibility reasons I guess we have no choice and need to mirror Firefox here (which in turn is stuck because Chrome apparently has no fixed limit at all…).

At least we're already compressing the on-disk session store files just like Firefox does, which should mitigate this potential size increase in session history for that kind of pages.