### PR TITLE
Update macOS version detection through 13 Ventura

### DIFF
--- a/browser/app/macbuild/Contents/Info.plist.in
+++ b/browser/app/macbuild/Contents/Info.plist.in
@@ -207,22 +207,29 @@
 	<string>public.app-category.productivity</string>
 	<key>LSFileQuarantineEnabled</key>
 	<true/>
+	<key>LSEnvironment</key>
+	<dict>
+		<key>SYSTEM_VERSION_COMPAT</key>
+		<string>0</string>
+	</dict>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.5.0</string>
-  <key>NSSupportsAutomaticGraphicsSwitching</key>
-  <true/>
-  <key>NSPrincipalClass</key>
-  <string>GeckoNSApplication</string>
+	<string>10.7.0</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
+	<key>NSPrincipalClass</key>
+	<string>GeckoNSApplication</string>
 	<key>SMPrivilegedExecutables</key>
 	<dict>
 		<key>org.mozilla.updater</key>
 		<string>identifier "org.mozilla.updater" and ((anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9]) or (anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] = "43AQ936H96"))</string>
 	</dict>
-  <key>NSDisablePersistence</key>
-  <true/>
-  <key>MozillaDeveloperRepoPath</key>
-  <string>%MOZ_DEVELOPER_REPO_PATH%</string>
-  <key>MozillaDeveloperObjPath</key>
-  <string>%MOZ_DEVELOPER_OBJ_PATH%</string>
+	<key>NSDisablePersistence</key>
+	<true/>
+	<key>MozillaDeveloperRepoPath</key>
+	<string>%MOZ_DEVELOPER_REPO_PATH%</string>
+	<key>MozillaDeveloperObjPath</key>
+	<string>%MOZ_DEVELOPER_OBJ_PATH%</string>
 </dict>
 </plist>

--- a/gfx/gl/GLContext.cpp
+++ b/gfx/gl/GLContext.cpp
@@ -880,8 +880,8 @@ GLContext::InitWithPrefixImpl(const char* prefix, bool trygl)
 
 #ifdef XP_MACOSX
     if (mWorkAroundDriverBugs &&
-        nsCocoaFeatures::OSXVersionMajor() == 10 &&
-        nsCocoaFeatures::OSXVersionMinor() < 12)
+        nsCocoaFeatures::macOSVersionMajor() == 10 &&
+        nsCocoaFeatures::macOSVersionMinor() < 12)
     {
         if (mVendor == GLVendor::Intel) {
             // see bug 737182 for 2D textures, bug 684882 for cube map textures.
@@ -1725,8 +1725,8 @@ GLContext::InitExtensions()
         // textures with glCompressedTexSubImage2D. Works on Intel HD 4000
         // and Intel HD 5000/Iris that I tested.
         // Bug 1124996: Appears to be the same on OSX Yosemite (10.10)
-        if (nsCocoaFeatures::OSXVersionMajor() == 10 &&
-            nsCocoaFeatures::OSXVersionMinor() >= 9 &&
+        if (nsCocoaFeatures::macOSVersionMajor() == 10 &&
+            nsCocoaFeatures::macOSVersionMinor() >= 9 &&
             Renderer() == GLRenderer::IntelHD3000)
         {
             MarkExtensionUnsupported(EXT_texture_compression_s3tc);

--- a/media/webrtc/trunk/build/mac/find_sdk.py
+++ b/media/webrtc/trunk/build/mac/find_sdk.py
@@ -52,7 +52,7 @@ def main():
       sdk_dir = xcode43_sdk_path
     else:
       sdk_dir = os.path.join(out.rstrip(), 'SDKs')
-    sdks = [re.findall('^MacOSX(10\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
+    sdks = [re.findall('^MacOSX(\d+\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
     sdks = [s[0] for s in sdks if s]  # [['10.5'], ['10.6']] => ['10.5', '10.6']
     sdks = [s for s in sdks  # ['10.5', '10.6'] => ['10.6']
             if parse_version(s) >= parse_version(min_sdk_version)]

--- a/netwerk/protocol/http/nsHttpHandler.cpp
+++ b/netwerk/protocol/http/nsHttpHandler.cpp
@@ -1047,8 +1047,8 @@ nsHttpHandler::InitUserAgentComponents()
 #elif defined(__i386__) || defined(__x86_64__)
     mOscpu.AssignLiteral("Intel Mac OS X");
 #endif
-    SInt32 majorVersion = nsCocoaFeatures::OSXVersionMajor();
-    SInt32 minorVersion = nsCocoaFeatures::OSXVersionMinor();
+    SInt32 majorVersion = nsCocoaFeatures::macOSVersionMajor();
+    SInt32 minorVersion = nsCocoaFeatures::macOSVersionMinor();
     mOscpu += nsPrintfCString(" %d.%d", static_cast<int>(majorVersion),
                               static_cast<int>(minorVersion));
 #elif defined (XP_UNIX)

--- a/toolkit/xre/nsNativeAppSupportCocoa.mm
+++ b/toolkit/xre/nsNativeAppSupportCocoa.mm
@@ -89,7 +89,7 @@ NS_IMETHODIMP nsNativeAppSupportCocoa::Start(bool *_retval)
   // alert here.  But the alert's message and buttons would require custom
   // localization.  So (for now at least) we just log an English message
   // to the console before quitting.
-  if (major < 10 || minor < 6) {
+  if (major < 10 || (major == 10 && minor < 7)) {
     NSLog(@"Minimum OS version requirement not met!");
     return NS_OK;
   }

--- a/widget/GfxDriverInfo.h
+++ b/widget/GfxDriverInfo.h
@@ -58,6 +58,13 @@ enum class OperatingSystem {
   OSX10_10,
   OSX10_11,
   OSX10_12,
+  OSX10_13,
+  OSX10_14,
+  OSX10_15,
+  OSX10_16,
+  OSX11_0,
+  OSX12_0,
+  OSX13_0,
   Android,
   Ios
 };

--- a/widget/GfxInfoBase.cpp
+++ b/widget/GfxInfoBase.cpp
@@ -298,6 +298,18 @@ BlacklistOSToOperatingSystem(const nsAString& os)
     return OperatingSystem::OSX10_11;
   else if (os.EqualsLiteral("Darwin 16"))
     return OperatingSystem::OSX10_12;
+  else if (os.EqualsLiteral("Darwin 17"))
+    return OperatingSystem::OSX10_13;
+  else if (os.EqualsLiteral("Darwin 18"))
+    return OperatingSystem::OSX10_14;
+  else if (os.EqualsLiteral("Darwin 19"))
+    return OperatingSystem::OSX10_15;
+  else if (os.EqualsLiteral("Darwin 20"))
+    return OperatingSystem::OSX11_0;
+  else if (os.EqualsLiteral("Darwin 21"))
+    return OperatingSystem::OSX12_0;
+  else if (os.EqualsLiteral("Darwin 22"))
+    return OperatingSystem::OSX13_0;
   else if (os.EqualsLiteral("Android"))
     return OperatingSystem::Android;
   // For historical reasons, "All" in blocklist means "All Windows"

--- a/widget/cocoa/GfxInfo.mm
+++ b/widget/cocoa/GfxInfo.mm
@@ -38,27 +38,50 @@ GfxInfo::GfxInfo() : mOSXVersion{0}
 static OperatingSystem
 OSXVersionToOperatingSystem(uint32_t aOSXVersion)
 {
-  if (nsCocoaFeatures::ExtractMajorVersion(aOSXVersion) == 10) {
-    switch (nsCocoaFeatures::ExtractMinorVersion(aOSXVersion)) {
-      case 6:
-        return OperatingSystem::OSX10_6;
-      case 7:
-        return OperatingSystem::OSX10_7;
-      case 8:
-        return OperatingSystem::OSX10_8;
-      case 9:
-        return OperatingSystem::OSX10_9;
-      case 10:
-        return OperatingSystem::OSX10_10;
-      case 11:
-        return OperatingSystem::OSX10_11;
-      case 12:
-        return OperatingSystem::OSX10_12;
-    }
+  switch (nsCocoaFeatures::ExtractMajorVersion(aOSXVersion)) {
+    case 10:
+      switch (nsCocoaFeatures::ExtractMinorVersion(aOSXVersion)) {
+        case 6:
+          return OperatingSystem::OSX10_6;
+        case 7:
+          return OperatingSystem::OSX10_7;
+        case 8:
+          return OperatingSystem::OSX10_8;
+        case 9:
+          return OperatingSystem::OSX10_9;
+        case 10:
+          return OperatingSystem::OSX10_10;
+        case 11:
+          return OperatingSystem::OSX10_11;
+        case 12:
+          return OperatingSystem::OSX10_12;
+        case 13:
+          return OperatingSystem::OSX10_13;
+        case 14:
+          return OperatingSystem::OSX10_14;
+        case 15:
+          return OperatingSystem::OSX10_15;
+        case 16:
+          // Depending on the SDK version, we either get 10.16 or 11.0.
+          // Normalize this to 11.0.
+          return OperatingSystem::OSX11_0;
+        default:
+          break;
+      }
+      break;
+    case 11:
+        return OperatingSystem::OSX11_0;
+    case 12:
+        return OperatingSystem::OSX12_0;
+    case 13:
+        return OperatingSystem::OSX13_0;
+    default:
+        break;
   }
 
   return OperatingSystem::Unknown;
 }
+
 // The following three functions are derived from Chromium code
 static CFTypeRef SearchPortForProperty(io_registry_entry_t dspPort,
                                        CFStringRef propertyName)
@@ -113,7 +136,7 @@ GfxInfo::Init()
 
   AddCrashReportAnnotations();
 
-  mOSXVersion = nsCocoaFeatures::OSXVersion();
+  mOSXVersion = nsCocoaFeatures::macOSVersion();
 
   return rv;
 }

--- a/widget/cocoa/nsAppShell.mm
+++ b/widget/cocoa/nsAppShell.mm
@@ -334,9 +334,9 @@ nsAppShell::Init()
   // The bug that this works around was introduced in OS X 10.10.0
   // and fixed in OS X 10.10.2. Order these version checks so as
   // few as possible will actually end up running.
-  if (nsCocoaFeatures::OSXVersionMinor() == 10 &&
-      nsCocoaFeatures::OSXVersionBugFix() < 2 &&
-      nsCocoaFeatures::OSXVersionMajor() == 10) {
+  if (nsCocoaFeatures::macOSVersionMinor() == 10 &&
+      nsCocoaFeatures::macOSVersionBugFix() < 2 &&
+      nsCocoaFeatures::macOSVersionMajor() == 10) {
     // Explicitly turn off CGEvent logging.  This works around bug 1092855.
     // If there are already CGEvents in the log, turning off logging also
     // causes those events to be written to disk.  But at this point no

--- a/widget/cocoa/nsCocoaFeatures.h
+++ b/widget/cocoa/nsCocoaFeatures.h
@@ -14,16 +14,23 @@
 /// is the only call that returns the unadjusted values.
 class nsCocoaFeatures {
 public:
-  static int32_t OSXVersion();
-  static int32_t OSXVersionMajor();
-  static int32_t OSXVersionMinor();
-  static int32_t OSXVersionBugFix();
+  static int32_t macOSVersion();
+  static int32_t macOSVersionMajor();
+  static int32_t macOSVersionMinor();
+  static int32_t macOSVersionBugFix();
   static bool OnYosemiteOrLater();
   static bool OnElCapitanOrLater();
   static bool OnSierraOrLater();
+  static bool OnHighSierraOrLater();
   static bool OnMojaveOrLater();
+  static bool OnCatalinaOrLater();
+  static bool OnBigSurOrLater();
+  static bool OnMontereyOrLater();
+  static bool OnVenturaOrLater();
 
   static bool IsAtLeastVersion(int32_t aMajor, int32_t aMinor, int32_t aBugFix=0);
+
+  static bool ProcessIsRosettaTranslated();
 
   // These are utilities that do not change or depend on the value of mOSXVersion
   // and instead just encapsulate the encoding algorithm.  Note that GetVersion
@@ -38,7 +45,7 @@ public:
 private:
   static void InitializeVersionNumbers();
 
-  static int32_t mOSXVersion;
+  static int32_t mOSVersion;
 };
 
 // C-callable helper for cairo-quartz-font.c

--- a/widget/cocoa/nsCocoaFeatures.mm
+++ b/widget/cocoa/nsCocoaFeatures.mm
@@ -3,23 +3,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// This file makes some assumptions about the versions of OS X.
+// This file makes some assumptions about the versions of macOS.
 // We are assuming that the minor and bugfix versions are less than 16.
+// We are assuming that the major, minor and bugfix versions are each less than
+// 256.
 // There are MOZ_ASSERTs for that.
 
-// The formula for the version integer based on OS X version 10.minor.bugfix is
-// 0x1000 + (minor << 4) + bugifix.  See AssembleVersion() below for major > 10.
-// Major version < 10 is not allowed.
+// The formula for the version integer is (major << 16) + (minor << 8) + bugfix.
 
-#define MAC_OS_X_VERSION_MASK      0x0000FFFF
-#define MAC_OS_X_VERSION_10_0_HEX  0x00001000
-#define MAC_OS_X_VERSION_10_7_HEX  0x00001070
-#define MAC_OS_X_VERSION_10_8_HEX  0x00001080
-#define MAC_OS_X_VERSION_10_9_HEX  0x00001090
-#define MAC_OS_X_VERSION_10_10_HEX 0x000010A0
-#define MAC_OS_X_VERSION_10_11_HEX 0x000010B0
-#define MAC_OS_X_VERSION_10_12_HEX 0x000010C0
-#define MAC_OS_X_VERSION_10_14_HEX 0x000010E0
+#define MACOS_VERSION_MASK 0x00FFFFFF
+#define MACOS_MAJOR_VERSION_MASK 0x00FFFFFF
+#define MACOS_MINOR_VERSION_MASK 0x00FFFFFF
+#define MACOS_BUGFIX_VERSION_MASK 0x00FFFFFF
+#define MACOS_VERSION_10_0_HEX 0x000A0000
+#define MACOS_VERSION_10_7_HEX 0x000A0700
+#define MACOS_VERSION_10_8_HEX 0x000A0800
+#define MACOS_VERSION_10_9_HEX 0x000A0900
+#define MACOS_VERSION_10_10_HEX 0x000A0A00
+#define MACOS_VERSION_10_11_HEX 0x000A0B00
+#define MACOS_VERSION_10_12_HEX 0x000A0C00
+#define MACOS_VERSION_10_13_HEX 0x000A0D00
+#define MACOS_VERSION_10_14_HEX 0x000A0E00
+#define MACOS_VERSION_10_15_HEX 0x000A0F00
+#define MACOS_VERSION_10_16_HEX 0x000A1000
+#define MACOS_VERSION_11_0_HEX 0x000B0000
+#define MACOS_VERSION_12_0_HEX 0x000C0000
+#define MACOS_VERSION_13_0_HEX 0x000D0000
 
 #include "nsCocoaFeatures.h"
 #include "nsCocoaUtils.h"
@@ -27,32 +36,33 @@
 #include "nsObjCExceptions.h"
 
 #import <Cocoa/Cocoa.h>
+#include <sys/sysctl.h>
 
-int32_t nsCocoaFeatures::mOSXVersion = 0;
+int32_t nsCocoaFeatures::mOSVersion = 0;
 
 // This should not be called with unchecked aMajor, which should be >= 10.
 inline int32_t AssembleVersion(int32_t aMajor, int32_t aMinor, int32_t aBugFix)
 {
     MOZ_ASSERT(aMajor >= 10);
-    return MAC_OS_X_VERSION_10_0_HEX + (aMajor-10) * 0x100 + (aMinor << 4) + aBugFix;
+    return (aMajor << 16) + (aMinor << 8) + aBugFix;
 }
 
 int32_t nsCocoaFeatures::ExtractMajorVersion(int32_t aVersion)
 {
-    MOZ_ASSERT((aVersion & MAC_OS_X_VERSION_MASK) == aVersion);
-    return ((aVersion & 0xFF00) - 0x1000) / 0x100 + 10;
+    MOZ_ASSERT((aVersion & MACOS_VERSION_MASK) == aVersion);
+    return (aVersion & 0xFF0000) >> 16;
 }
 
 int32_t nsCocoaFeatures::ExtractMinorVersion(int32_t aVersion)
 {
-    MOZ_ASSERT((aVersion & MAC_OS_X_VERSION_MASK) == aVersion);
-    return (aVersion & 0xF0) >> 4;
+    MOZ_ASSERT((aVersion & MACOS_VERSION_MASK) == aVersion);
+    return (aVersion & 0xFF00) >> 8;
 }
 
 int32_t nsCocoaFeatures::ExtractBugFixVersion(int32_t aVersion)
 {
-    MOZ_ASSERT((aVersion & MAC_OS_X_VERSION_MASK) == aVersion);
-    return aVersion & 0x0F;
+    MOZ_ASSERT((aVersion & MACOS_VERSION_MASK) == aVersion);
+    return aVersion & 0xFF;
 }
 
 static int intAtStringIndex(NSArray *array, int index)
@@ -81,26 +91,28 @@ void nsCocoaFeatures::GetSystemVersion(int &major, int &minor, int &bugfix)
 
 int32_t nsCocoaFeatures::GetVersion(int32_t aMajor, int32_t aMinor, int32_t aBugFix)
 {
-    int32_t osxVersion;
+    int32_t macOSVersion;
     if (aMajor < 10) {
         aMajor = 10;
-        NS_ERROR("Couldn't determine OS X version, assuming 10.7");
-        osxVersion = MAC_OS_X_VERSION_10_7_HEX;
-    } else if (aMinor < 7) {
+        NS_ERROR("Couldn't determine macOS version, assuming 10.7");
+        macOSVersion = MACOS_VERSION_10_7_HEX;
+    } else if (aMajor == 10 && aMinor < 7) {
         aMinor = 7;
-        NS_ERROR("OS X version too old, assuming 10.7");
-        osxVersion = MAC_OS_X_VERSION_10_7_HEX;
+        NS_ERROR("macOS version too old, assuming 10.7");
+        macOSVersion = MACOS_VERSION_10_7_HEX;
     } else {
-        MOZ_ASSERT(aMajor == 10); // For now, even though we're ready...
-        MOZ_ASSERT(aMinor < 16);
+        MOZ_ASSERT(aMajor >= 10);
+        MOZ_ASSERT(aMajor < 256);
+        MOZ_ASSERT(aMinor >= 0);
+        MOZ_ASSERT(aMinor < 256);
         MOZ_ASSERT(aBugFix >= 0);
-        MOZ_ASSERT(aBugFix < 16);
-        osxVersion = AssembleVersion(aMajor, aMinor, aBugFix);
+        MOZ_ASSERT(aBugFix < 256);
+        macOSVersion = AssembleVersion(aMajor, aMinor, aBugFix);
     }
-    MOZ_ASSERT(aMajor == ExtractMajorVersion(osxVersion));
-    MOZ_ASSERT(aMinor == ExtractMinorVersion(osxVersion));
-    MOZ_ASSERT(aBugFix == ExtractBugFixVersion(osxVersion));
-    return osxVersion;
+    MOZ_ASSERT(aMajor == ExtractMajorVersion(macOSVersion));
+    MOZ_ASSERT(aMinor == ExtractMinorVersion(macOSVersion));
+    MOZ_ASSERT(aBugFix == ExtractBugFixVersion(macOSVersion));
+    return macOSVersion;
 }
 
 /*static*/ void
@@ -114,58 +126,57 @@ nsCocoaFeatures::InitializeVersionNumbers()
 
     int major, minor, bugfix;
     GetSystemVersion(major, minor, bugfix);
-    mOSXVersion = GetVersion(major, minor, bugfix);
+    mOSVersion = GetVersion(major, minor, bugfix);
 
     NS_OBJC_END_TRY_ABORT_BLOCK;
 }
 
 /* static */ int32_t
-nsCocoaFeatures::OSXVersion()
+nsCocoaFeatures::macOSVersion()
 {
     // Don't let this be called while we're first setting the value...
-    MOZ_ASSERT((mOSXVersion & MAC_OS_X_VERSION_MASK) >= 0);
-    if (!mOSXVersion) {
-        mOSXVersion = -1;
+    MOZ_ASSERT((mOSVersion & MACOS_VERSION_MASK) >= 0);
+    if (!mOSVersion) {
+        mOSVersion = -1;
         InitializeVersionNumbers();
     }
-    return mOSXVersion;
+    return mOSVersion;
 }
 
 /* static */ int32_t
-nsCocoaFeatures::OSXVersionMajor()
+nsCocoaFeatures::macOSVersionMajor()
 {
-    MOZ_ASSERT((OSXVersion() & MAC_OS_X_VERSION_10_0_HEX) == MAC_OS_X_VERSION_10_0_HEX);
-    return 10;
+    return ExtractMajorVersion(macOSVersion());
 }
 
 /* static */ int32_t
-nsCocoaFeatures::OSXVersionMinor()
+nsCocoaFeatures::macOSVersionMinor()
 {
-    return ExtractMinorVersion(OSXVersion());
+    return ExtractMinorVersion(macOSVersion());
 }
 
 /* static */ int32_t
-nsCocoaFeatures::OSXVersionBugFix()
+nsCocoaFeatures::macOSVersionBugFix()
 {
-    return ExtractBugFixVersion(OSXVersion());
+    return ExtractBugFixVersion(macOSVersion());
 }
 
 /* static */ bool
 nsCocoaFeatures::OnYosemiteOrLater()
 {
-    return (OSXVersion() >= MAC_OS_X_VERSION_10_10_HEX);
+    return (macOSVersion() >= MACOS_VERSION_10_10_HEX);
 }
 
 /* static */ bool
 nsCocoaFeatures::OnElCapitanOrLater()
 {
-    return (OSXVersion() >= MAC_OS_X_VERSION_10_11_HEX);
+    return (macOSVersion() >= MACOS_VERSION_10_11_HEX);
 }
 
 /* static */ bool
 nsCocoaFeatures::OnSierraOrLater()
 {
-    return (OSXVersion() >= MAC_OS_X_VERSION_10_12_HEX);
+    return (macOSVersion() >= MACOS_VERSION_10_12_HEX);
 }
 
 /* Version of OnSierraOrLater as a global function callable from C (cairo) */
@@ -175,14 +186,80 @@ Gecko_OnSierraOrLater()
     return nsCocoaFeatures::OnSierraOrLater();
 }
 
+/* static */ bool 
+nsCocoaFeatures::OnHighSierraOrLater() 
+{
+    return (macOSVersion() >= MACOS_VERSION_10_13_HEX);
+}
+
 /* static */ bool
 nsCocoaFeatures::OnMojaveOrLater()
 {
-    return (OSXVersion() >= MAC_OS_X_VERSION_10_14_HEX);
+    return (macOSVersion() >= MACOS_VERSION_10_14_HEX);
+}
+
+/* static */ bool 
+nsCocoaFeatures::OnCatalinaOrLater() 
+{
+    return (macOSVersion() >= MACOS_VERSION_10_15_HEX);
+}
+
+/* static */ bool
+nsCocoaFeatures::OnBigSurOrLater()
+{
+    // Account for the version being 10.16 or 11.0 on Big Sur.
+    // The version is reported as 10.16 if SYSTEM_VERSION_COMPAT is set to 1,
+    // or if SYSTEM_VERSION_COMPAT is not set and the application is linked
+    // with a pre-Big Sur SDK.
+    // We should set SYSTEM_VERSION_COMPAT to 0 in its Info.plist, so it'll
+    // usually see the correct 11.* version, despite being linked against an
+    // old SDK. However, it still sees the 10.16 compatibility version when
+    // launched from the command line, see bug 1727624. (This only applies to
+    // the Intel build - the arm64 build is linked against a Big Sur SDK and
+    // always sees the correct version.)
+    return ((macOSVersion() >= MACOS_VERSION_10_16_HEX) ||
+            (macOSVersion() >= MACOS_VERSION_11_0_HEX));
+}
+
+/* static */ bool 
+nsCocoaFeatures::OnMontereyOrLater() 
+{
+    // Monterey pretends to be 10.16 and is indistinguishable from Big Sur.
+    // In practice, this means that an Intel build can return false
+    // from this function if it's launched from the command line, see bug 1727624.
+    // This will not be an issue anymore once we link against the Big Sur SDK.
+    return (macOSVersion() >= MACOS_VERSION_12_0_HEX);
+}
+
+/* static */ bool 
+nsCocoaFeatures::OnVenturaOrLater() 
+{
+    return (macOSVersion() >= MACOS_VERSION_13_0_HEX);
 }
 
 /* static */ bool
 nsCocoaFeatures::IsAtLeastVersion(int32_t aMajor, int32_t aMinor, int32_t aBugFix)
 {
-    return OSXVersion() >= GetVersion(aMajor, aMinor, aBugFix);
+    return macOSVersion() >= GetVersion(aMajor, aMinor, aBugFix);
+}
+
+/*
+ * Returns true if the process is running under Rosetta translation. Returns
+ * false if running natively or if an error was encountered. We use the
+ * `sysctl.proc_translated` sysctl which is documented by Apple to be used
+ * for this purpose. Note: using this in a sandboxed process requires allowing
+ * the sysctl in the sandbox policy.
+ */
+/* static */ bool 
+nsCocoaFeatures::ProcessIsRosettaTranslated()
+{
+    int ret = 0;
+    size_t size = sizeof(ret);
+    if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {
+        if (errno != ENOENT) {
+            fprintf(stderr, "Failed to check for translation environment\n");
+        }
+        return false;
+    }
+    return (ret == 1);
 }

--- a/xpcom/components/ManifestParser.cpp
+++ b/xpcom/components/ManifestParser.cpp
@@ -542,8 +542,8 @@ ParseManifest(NSLocationType aType, FileLocation& aFile, char* aBuf,
   }
 #pragma warning(pop)
 #elif defined(MOZ_WIDGET_COCOA)
-  SInt32 majorVersion = nsCocoaFeatures::OSXVersionMajor();
-  SInt32 minorVersion = nsCocoaFeatures::OSXVersionMinor();
+  SInt32 majorVersion = nsCocoaFeatures::macOSVersionMajor();
+  SInt32 minorVersion = nsCocoaFeatures::macOSVersionMinor();
   nsTextFormatter::ssprintf(osVersion, u"%ld.%ld",
                             majorVersion,
                             minorVersion);


### PR DESCRIPTION
This updates version detection and the blacklist. It also allows webrtc to find SDKs 11.0 and higher.  Also standardize the minimum version of MacOS as 10.7.  There were 3 different versions: mozconfig specified 10.7, Info.plist 10.5 and the version detection code 10.6.  Can revisit this if someone wants to build for older versions, but I only have Intel machines 10.7 and higher.  Also force light mode on newer SDKs via Info.plist.

These changes lay the groundwork for Apple Silicon builds if anyone is interested in Waterfox Classic on Apple Silicon.