### PR TITLE
Avoid Ion crash due to logical assignment operators

### DIFF
--- a/js/src/frontend/BytecodeEmitter.cpp
+++ b/js/src/frontend/BytecodeEmitter.cpp
@@ -4470,6 +4470,10 @@ bool BytecodeEmitter::emitShortCircuitAssignment(ParseNode* pn) {
 
   // Join with the short-circuit jump and pop anything left on the stack.
   if (numPushed > 0) {
+    if (!newSrcNote(SRC_LOGICASSIGN)) {
+      return false;
+    }
+
     JumpList jumpAroundPop;
     if (!emitJump(JSOP_GOTO, &jumpAroundPop)) {
       //            [stack] RHS

--- a/js/src/frontend/SourceNotes.h
+++ b/js/src/frontend/SourceNotes.h
@@ -50,6 +50,7 @@ namespace js {
     M(SRC_BREAK,        "break",       0)  /* JSOP_GOTO is a break. */                             \
     M(SRC_BREAK2LABEL,  "break2label", 0)  /* JSOP_GOTO for 'break label'. */                      \
     M(SRC_SWITCHBREAK,  "switchbreak", 0)  /* JSOP_GOTO is a break in a switch. */                 \
+    M(SRC_LOGICASSIGN,  "logicassign", 0)  /* JSOP_GOTO is for logical assignment operator. */     \
     M(SRC_TABLESWITCH,  "tableswitch", 1)  /* JSOP_TABLESWITCH; offset points to end of switch. */ \
     M(SRC_CONDSWITCH,   "condswitch",  2)  /* JSOP_CONDSWITCH; 1st offset points to end of switch, \
                                               2nd points to first JSOP_CASE. */                    \
@@ -64,7 +65,6 @@ namespace js {
     M(SRC_COLSPAN,      "colspan",     1)  /* Number of columns this opcode spans. */              \
     M(SRC_NEWLINE,      "newline",     0)  /* Bytecode follows a source newline. */                \
     M(SRC_SETLINE,      "setline",     1)  /* A file-absolute source line number note. */          \
-    M(SRC_UNUSED21,     "unused21",    0)  /* Unused. */                                           \
     M(SRC_UNUSED22,     "unused22",    0)  /* Unused. */                                           \
     M(SRC_UNUSED23,     "unused23",    0)  /* Unused. */                                           \
     M(SRC_XDELTA,       "xdelta",      0)  /* 24-31 are for extended delta notes. */

--- a/js/src/jit/IonControlFlow.cpp
+++ b/js/src/jit/IonControlFlow.cpp
@@ -296,6 +296,10 @@ ControlFlowGenerator::snoopControlFlow(JSOp op)
             // while (cond) { }
             return processWhileOrForInLoop(sn);
 
+          case SRC_LOGICASSIGN:
+            // Not implemented yet.
+            return ControlStatus::Abort;
+
           default:
             // Hard assert for now - make an error later.
             MOZ_CRASH("unknown goto case");

--- a/netwerk/test/gtest/TestURIMutator.cpp
+++ b/netwerk/test/gtest/TestURIMutator.cpp
@@ -22,7 +22,7 @@ TEST(TestURIMutator, Mutator)
   rv = NS_MutateURI(uri)
          .SetScheme(NS_LITERAL_CSTRING("ftp"))
          .SetHost(NS_LITERAL_CSTRING("mozilla.org"))
-         .SetPathQueryRef(NS_LITERAL_CSTRING("/path?query#ref"))
+         .SetPath(NS_LITERAL_CSTRING("/path?query#ref"))
          .Finalize(uri);
   ASSERT_EQ(rv, NS_OK);
   ASSERT_EQ(uri->GetSpec(out), NS_OK);


### PR DESCRIPTION
The Mozilla implementation of the logical assignment operators (see #138) uses a `JSOP_GOTO`, which in our version of SpiderMonkey still requires some special handling in `IonControlFlow.cpp`.

Until somebody understands that logic well enough to shoehorn in a proper solution, we need to disable Ion compilation when hitting a logical assignment operator in order to avoid triggering [the diagnostic crash here](https://github.com/WaterfoxCo/Waterfox-Classic/blob/efbad44d89e472afda72ccb5a156a06edf03eca7/js/src/jit/IonControlFlow.cpp#L301).

Note for posterity if somebody wants to take a closer look and get Ion compilation working again for this case: This code for example
```js
(e._jswReactRootContainer ||= (0, react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot)(e)).render(t);
```

gets compiled into this bytecode
```
# from ifeq @ 00188
00261:   1  jumptarget                  #
    00262:   1  zero                        # 0
    00263:   1  pop                         #
    00264:   1  getaliasedvar "react__WEBPACK_IMPORTED_MODULE_1__" (hops = 2, slot = 3) # react__WEBPACK_IMPORTED_MODULE_1__
    00269:   1  getprop "isValidElement"    # react__WEBPACK_IMPORTED_MODULE_1__.isValidElement
    00274:   1  undefined                   # react__WEBPACK_IMPORTED_MODULE_1__.isValidElement undefined
    00275:   1  getaliasedvar "t" (hops = 0, slot = 3) # react__WEBPACK_IMPORTED_MODULE_1__.isValidElement undefined t
    00280:   1  call 1                      # react__WEBPACK_IMPORTED_MODULE_1__.isValidElement(...)
    00283:   1  ifeq 363 (+80)              #
    00288:   1  jumptarget                  #
    00289:   1  getaliasedvar "e" (hops = 0, slot = 2) # e
    00294:   1  dup                         # e e
    00295:   1  getprop "_jswReactRootContainer" # e e._jswReactRootContainer
    00300:   1  or 338 (+38)                # e e._jswReactRootContainer
    00305:   1  jumptarget                  # e e._jswReactRootContainer
    00306:   1  pop                         # e
    00307:   1  zero                        # e 0
    00308:   1  pop                         # e
    00309:   1  getaliasedvar "react_dom_client__WEBPACK_IMPORTED_MODULE_0__" (hops = 2, slot = 2) # e react_dom_client__WEBPACK_IMPORTED_MODULE_0__
    00314:   1  getprop "createRoot"        # e react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot
    00319:   1  undefined                   # e react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot undefined
    00320:   1  getaliasedvar "e" (hops = 0, slot = 2) # e react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot undefined e
    00325:   1  call 1                      # e react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)
    00328:   1  strict-setprop "_jswReactRootContainer" # react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)
    00333:   1  goto 341 (+8)               # react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)

# from or @ 00300
00338:   1  jumptarget                  # e e._jswReactRootContainer
    00339:   1  swap                        # e._jswReactRootContainer e
    00340:   1  pop                         # e._jswReactRootContainer

# from goto @ 00333
00341:   1  jumptarget                  # merged<react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)>
    00342:   1  dup                         # merged<react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)> merged<react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)>
    00343:   1  callprop "render"           # merged<react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)> merged<react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)>.render
    00348:   1  swap                        # merged<react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)>.render merged<react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)>
    00349:   1  getaliasedvar "t" (hops = 0, slot = 3) # merged<react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)>.render merged<react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)> t
    00354:   1  call-ignores-rv 1           # merged<react_dom_client__WEBPACK_IMPORTED_MODULE_0__.createRoot(...)>.render(...)
    00357:   1  pop                         #
    00358:   1  goto 1299 (+941)            #
```

So whereas the regular short-circuiting operators (&&, ||, ??) roughly resemble a
```
…
if (!shortCircuitingConditionOnLeftHandSide) {
    evaluateRightHandSide()
}
…
```

with the logical assignment operators we now have something like
```
…
if (!shortCircuitingConditionOnLeftHandSide) {
    evaluateRightHandSideAndAssign()
} else {
    doSomeCleanup()
}
…
```

As [noted here](https://github.com/WaterfoxCo/Waterfox-Classic/blob/classic/js/src/jit/IonControlFlow.cpp#L1759-L1764), the bytecode for an if-then-else looks roughly like
```
    //    IFEQ X     ; src note (IF_ELSE, COND)
    //    ...
    //    GOTO Z
    // X: JUMPTARGET ; else/else if
    //    ...
    // Z: JUMPTARGET ; join
```
which is basically what we have here above between 00300: and 00341:, except that of course instead of `IFEQ` we're starting out with a `AND`/`OR`/`COALESCE` operator at the beginning.

So it should probably be possible to cobble something together by looking at the existing `processIf…` and `processShortCircuit…` routines in `IonControlFlow.cpp`.