### PR TITLE
Fix crash when clicking the green fullscreen button on MacOS 11.0 Big Sur and later

### DIFF
--- a/third_party/python/psutil/psutil/_psutil_posix.c
+++ b/third_party/python/psutil/psutil/_psutil_posix.c
@@ -23,6 +23,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <net/if_dl.h>
+#include <sys/ioctl.h>
 #endif
 
 #if defined(__sun)

--- a/widget/cocoa/nsCocoaWindow.mm
+++ b/widget/cocoa/nsCocoaWindow.mm
@@ -2916,6 +2916,9 @@ nsCocoaWindow::GetEditCommands(NativeKeyBindingsType aType,
 
 - (BOOL)FrameView__wantsFloatingTitlebar
 {
+  if(nsCocoaFeatures::OnBigSurOrLater()) {
+    return [super FrameView__wantsFloatingTitlebar];
+  }
   return NO;
 }
 
@@ -3042,7 +3045,7 @@ static NSMutableSet *gSwizzledFrameViewClasses = nil;
     IMP _wantsFloatingTitlebar =
       class_getMethodImplementation(frameViewClass,
                                     @selector(_wantsFloatingTitlebar));
-    if (_wantsFloatingTitlebar &&
+    if (!nsCocoaFeatures::OnBigSurOrLater() && _wantsFloatingTitlebar &&
         _wantsFloatingTitlebar != our_wantsFloatingTitlebar) {
       nsToolkit::SwizzleMethods(frameViewClass, @selector(_wantsFloatingTitlebar),
                                 @selector(FrameView__wantsFloatingTitlebar));


### PR DESCRIPTION
This is hopefully the least impact that can be made, by selectively disabling the offending code only on the affected versions of MacOS. 

Mozilla replaced this code entirely with a new titlebarHeight override method in current versions.  This change does not switch to any new methods and just leaves everything as it was in unaffected versions. 

I believe when this pull request is merged Issue #94 can probably be closed.  It lists 3 problems, this fixes one of them, another was fixed by my previous pull request and the last sync issue sounded like it was fixed a while ago. 

I also included a minor unrelated fix that is only used by an optional component in the build system. The fix allows the psutil python extension to build on MacOS and possibly FreeBSD. 